### PR TITLE
Add GraphQL backend

### DIFF
--- a/db/migrations/.gitignore
+++ b/db/migrations/.gitignore
@@ -1,0 +1,1 @@
+test_data.sql

--- a/db/migrations/000_init.sql
+++ b/db/migrations/000_init.sql
@@ -1,0 +1,37 @@
+-- Adminer 4.7.7 PostgreSQL dump
+
+\connect "gripedotdev";
+
+CREATE SEQUENCE posts_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
+
+CREATE TABLE "public"."posts" IF NOT EXISTS (
+    "id" integer DEFAULT nextval('posts_id_seq') NOT NULL,
+    "content" text NOT NULL,
+    "created" timestamp NOT NULL,
+    "updated" timestamp NOT NULL,
+    "icon" character varying(255) NOT NULL,
+    "user_id" integer,
+    CONSTRAINT "posts_id" PRIMARY KEY ("id"),
+    CONSTRAINT "posts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL NOT DEFERRABLE
+) WITH (oids = false);
+
+CREATE TABLE "public"."reactions" IF NOT EXISTS (
+    "user_id" integer NOT NULL,
+    "post_id" integer NOT NULL,
+    "reaction" character varying(255) NOT NULL,
+    CONSTRAINT "reactions_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE NOT DEFERRABLE,
+    CONSTRAINT "reactions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT DEFERRABLE
+) WITH (oids = false);
+
+CREATE INDEX "reactions_post_id" ON "public"."reactions" USING btree ("post_id");
+
+CREATE INDEX "reactions_user_id" ON "public"."reactions" USING btree ("user_id");
+
+CREATE SEQUENCE users_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
+
+CREATE TABLE "public"."users" IF NOT EXISTS (
+    "id" integer DEFAULT nextval('users_id_seq') NOT NULL,
+    "name" text NOT NULL,
+    "info" json NOT NULL,
+    CONSTRAINT "users_id" PRIMARY KEY ("id")
+) WITH (oids = false);

--- a/db/migrations/000_init.sql
+++ b/db/migrations/000_init.sql
@@ -1,24 +1,38 @@
+-- 000_init.sql
 -- Adminer 4.7.7 PostgreSQL dump
 
 \connect "gripedotdev";
 
+DROP TABLE IF EXISTS "users";
+DROP SEQUENCE IF EXISTS users_id_seq;
+CREATE SEQUENCE users_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
+
+CREATE TABLE "public"."users" (
+    "id" integer DEFAULT nextval('users_id_seq') NOT NULL,
+    "name" text NOT NULL,
+    CONSTRAINT "users_id" PRIMARY KEY ("id")
+) WITH (oids = false);
+
+DROP TABLE IF EXISTS "posts";
+DROP SEQUENCE IF EXISTS posts_id_seq;
 CREATE SEQUENCE posts_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
 
-CREATE TABLE "public"."posts" IF NOT EXISTS (
+CREATE TABLE "public"."posts" (
     "id" integer DEFAULT nextval('posts_id_seq') NOT NULL,
     "content" text NOT NULL,
     "created" timestamp NOT NULL,
-    "updated" timestamp NOT NULL,
     "icon" character varying(255) NOT NULL,
     "user_id" integer,
     CONSTRAINT "posts_id" PRIMARY KEY ("id"),
     CONSTRAINT "posts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL NOT DEFERRABLE
 ) WITH (oids = false);
 
-CREATE TABLE "public"."reactions" IF NOT EXISTS (
+DROP TABLE IF EXISTS "reactions";
+CREATE TABLE "public"."reactions" (
     "user_id" integer NOT NULL,
     "post_id" integer NOT NULL,
     "reaction" character varying(255) NOT NULL,
+    CONSTRAINT "reactions_user_id_post_id_reaction" UNIQUE ("user_id", "post_id", "reaction"),
     CONSTRAINT "reactions_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE NOT DEFERRABLE,
     CONSTRAINT "reactions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT DEFERRABLE
 ) WITH (oids = false);
@@ -26,12 +40,3 @@ CREATE TABLE "public"."reactions" IF NOT EXISTS (
 CREATE INDEX "reactions_post_id" ON "public"."reactions" USING btree ("post_id");
 
 CREATE INDEX "reactions_user_id" ON "public"."reactions" USING btree ("user_id");
-
-CREATE SEQUENCE users_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
-
-CREATE TABLE "public"."users" IF NOT EXISTS (
-    "id" integer DEFAULT nextval('users_id_seq') NOT NULL,
-    "name" text NOT NULL,
-    "info" json NOT NULL,
-    CONSTRAINT "users_id" PRIMARY KEY ("id")
-) WITH (oids = false);

--- a/db/test_data.sql
+++ b/db/test_data.sql
@@ -1,0 +1,45 @@
+-- test_data.sql
+
+\connect "gripedotdev";
+
+INSERT INTO "users" ("id", "name") VALUES
+(1,	'Dylan Sheffer'),
+(2,	'Austin Schaffer'),
+(3,	'Tim Giles'),
+(4,	'Blair Stinson');
+
+INSERT INTO "posts" ("id", "content", "created", "icon", "user_id") VALUES
+(5,	'my life is nothing but gripes',	'2020-09-30 18:20:08.298457',	'🗿',	3),
+(6,	'there has to be a better patching process than:
+
+1) Do work
+2) Merge to dev
+3) verify it works on dev
+4) blindly cherry-pick to staging
+5) hope it works once a new staging post happens',	'2020-09-30 18:21:14.502485',	'🤦',	4),
+(7,	'New Android continues to disappoint',	'2020-09-30 18:21:41.17065',	'👌',	1),
+(8,	'The python tools for VSCode are pretty good, but the linter only runs on the current file when you save the current file, so you can''t refactor things by:
+
+1. Deleting the thing
+2. Resolving the errors',	'2020-09-30 18:22:40.871817',	'🕴',	2),
+(9,	'Who the fuck thought it would be a good idea to nest all java projects in at minimum 3 folder',	'2020-09-30 18:23:15.462048',	'😡',	4),
+(11,	'You can''t run and test firebase locally',	'2020-09-30 18:24:12.071185',	'🙄',	2),
+(10,	'My team at work is 1 person work now. Also, all the official work repos are on my personal github
+
+¯\_(ツ)_/¯
+
+That''s not a shrug emote, that''s me carrying the department on my back',	'2020-09-30 18:23:52.553874',	'🤷',	NULL);
+
+INSERT INTO "reactions" ("user_id", "post_id", "reaction") VALUES
+(1,	7,	'💯'),
+(2,	7,	'💯'),
+(3,	7,	'💯'),
+(4,	7,	'💯'),
+(1,	8,	'💯'),
+(2,	8,	'💯'),
+(3,	8,	'💯'),
+(4,	8,	'💯'),
+(1,	8,	'🗿'),
+(2,	8,	'🗿'),
+(3,	8,	'🗿'),
+(4,	8,	'🗿');

--- a/db/test_data.sql
+++ b/db/test_data.sql
@@ -28,7 +28,8 @@ INSERT INTO "posts" ("id", "content", "created", "icon", "user_id") VALUES
 
 ¯\_(ツ)_/¯
 
-That''s not a shrug emote, that''s me carrying the department on my back',	'2020-09-30 18:23:52.553874',	'🤷',	NULL);
+That''s not a shrug emote, that''s me carrying the department on my back',	'2020-09-30 18:23:52.553874',	'🤷',	NULL),
+(12,	'Working out makes me sore 😡',	'2020-09-30 18:23:15.462048',	'😡',	1);
 
 INSERT INTO "reactions" ("user_id", "post_id", "reaction") VALUES
 (1,	7,	'💯'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,25 @@
 version: "3.2"
 
 services:
+  #
+  # Backend Services
+  #
+
+  # Postgres database (dev)
   postgres:
     image: postgres:12.4
     restart: always
     environment:
-      POSTGRES_USER: username
+      POSTGRES_USER: gripedotdev
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: gripedotdev
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./db/migrations/:/docker-entrypoint-initdb.d/
+      - ./db/test_data.sql:/docker-entrypoint-initdb.d/test_data.sql
     networks:
       - postgres_network
 
-  # in-browser SQL GUI
+  # in-browser SQL GUI (dev, optional)
   adminer:
     image: adminer
     restart: always
@@ -25,25 +30,29 @@ services:
     depends_on:
       - postgres
 
-  postgraphile:
+  # GraphQL API
+  graphql:
     image: graphile/postgraphile:4
     restart: always
     ports:
       - "5000:5000"
     environment:
-      DATABASE_URL: postgres://username:password@postgres/gripedotdev
+      DATABASE_URL: postgres://gripedotdev:password@postgres/gripedotdev
     networks:
       - postgres_network
     depends_on:
       - postgres
 
+  #
+  # Frontend Services
+  #
   webapp:
     image: gripedotdev/webapp
     build: .
     ports:
       - 4200:80
     depends_on:
-      - postgraphile
+      - graphql
 
 networks:
   postgres_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,52 @@
 version: "3.2"
 
 services:
+  postgres:
+    image: postgres:12.4
+    restart: always
+    environment:
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: gripedotdev
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./db/migrations/:/docker-entrypoint-initdb.d/
+    networks:
+      - postgres_network
+
+  # in-browser SQL GUI
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - "8080:8080"
+    networks:
+      - postgres_network
+    depends_on:
+      - postgres
+
+  postgraphile:
+    image: graphile/postgraphile:4
+    restart: always
+    ports:
+      - "5000:5000"
+    environment:
+      DATABASE_URL: postgres://username:password@postgres/gripedotdev
+    networks:
+      - postgres_network
+    depends_on:
+      - postgres
+
   webapp:
     image: gripedotdev/webapp
     build: .
     ports:
       - 4200:80
+    depends_on:
+      - postgraphile
+
+networks:
+  postgres_network:
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Adds a basic schema implemented in Postgres abstracted behind a GraphQL API, supporting basic CRUD operations for users/posts/reactions. Adds 3 new services to the docker-compose file to support the new backend, including a postgres instance for local dev work, an adminer service so dev's don't have to install a postgres client, and a postgraphile service which exposes the GraphQL API. The initial db scripts also populate the database with test data gathered from `src/app/gripes/gripes.ts`

![image](https://user-images.githubusercontent.com/16184219/94729708-0f017780-0330-11eb-967d-cd68b4aceadf.png)

The initial schema and backend do not support:

- post edit history (no JSON blob for history, no "last modified" column)
- user login information (no username/password columns)
- federated login information (backing store for login with GitHub/Google/Facebook/etc)

closes #34 