### PR TITLE
feat: add user login credentials

### DIFF
--- a/db/migrations/000_init.sql
+++ b/db/migrations/000_init.sql
@@ -1,42 +1,29 @@
 -- 000_init.sql
--- Adminer 4.7.7 PostgreSQL dump
 
-\connect "gripedotdev";
+-- users table
+create sequence "users_id_seq" increment 1 minvalue 1 maxvalue 2147483647 start 1 cache 1;
+create table "public"."users" (
+    "id" integer primary key default nextval('users_id_seq') not null,
+    "name" text not null
+);
 
-DROP TABLE IF EXISTS "users";
-DROP SEQUENCE IF EXISTS users_id_seq;
-CREATE SEQUENCE users_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
+-- posts table, FK on users table
+create sequence "posts_id_seq" increment 1 minvalue 1 maxvalue 2147483647 start 1 cache 1;
+create table "public"."posts" (
+    "id" integer primary key default nextval('posts_id_seq') not null,
+    "content" text not null,
+    "created" timestamp not null,
+    "icon" character varying(255) not null,
+    "user_id" integer references users(id) on delete set null not deferrable
+);
+create index "posts_user_id" on "public"."posts" using btree ("user_id");
 
-CREATE TABLE "public"."users" (
-    "id" integer DEFAULT nextval('users_id_seq') NOT NULL,
-    "name" text NOT NULL,
-    CONSTRAINT "users_id" PRIMARY KEY ("id")
-) WITH (oids = false);
-
-DROP TABLE IF EXISTS "posts";
-DROP SEQUENCE IF EXISTS posts_id_seq;
-CREATE SEQUENCE posts_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1;
-
-CREATE TABLE "public"."posts" (
-    "id" integer DEFAULT nextval('posts_id_seq') NOT NULL,
-    "content" text NOT NULL,
-    "created" timestamp NOT NULL,
-    "icon" character varying(255) NOT NULL,
-    "user_id" integer,
-    CONSTRAINT "posts_id" PRIMARY KEY ("id"),
-    CONSTRAINT "posts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL NOT DEFERRABLE
-) WITH (oids = false);
-
-DROP TABLE IF EXISTS "reactions";
-CREATE TABLE "public"."reactions" (
-    "user_id" integer NOT NULL,
-    "post_id" integer NOT NULL,
-    "reaction" character varying(255) NOT NULL,
-    CONSTRAINT "reactions_user_id_post_id_reaction" UNIQUE ("user_id", "post_id", "reaction"),
-    CONSTRAINT "reactions_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE NOT DEFERRABLE,
-    CONSTRAINT "reactions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT DEFERRABLE
-) WITH (oids = false);
-
-CREATE INDEX "reactions_post_id" ON "public"."reactions" USING btree ("post_id");
-
-CREATE INDEX "reactions_user_id" ON "public"."reactions" USING btree ("user_id");
+-- reactions table, FKs on users/posts tables
+create table "public"."reactions" (
+    "user_id" integer not null references users(id) on delete cascade not deferrable,
+    "post_id" integer not null references posts(id) on delete cascade not deferrable,
+    "reaction" character varying(255) not null,
+    constraint "reactions_user_id_post_id_reaction" unique ("user_id", "post_id", "reaction")
+);
+create index "reactions_post_id" on "public"."reactions" using btree ("post_id");
+create index "reactions_user_id" on "public"."reactions" using btree ("user_id");

--- a/db/migrations/000_init.sql
+++ b/db/migrations/000_init.sql
@@ -2,28 +2,30 @@
 
 -- users table
 create sequence "users_id_seq" increment 1 minvalue 1 maxvalue 2147483647 start 1 cache 1;
-create table "public"."users" (
+create table public.users (
     "id" integer primary key default nextval('users_id_seq') not null,
     "name" text not null
 );
 
 -- posts table, FK on users table
 create sequence "posts_id_seq" increment 1 minvalue 1 maxvalue 2147483647 start 1 cache 1;
-create table "public"."posts" (
+create table public.posts (
     "id" integer primary key default nextval('posts_id_seq') not null,
     "content" text not null,
     "created" timestamp not null,
     "icon" character varying(255) not null,
     "user_id" integer references users(id) on delete set null not deferrable
 );
-create index "posts_user_id" on "public"."posts" using btree ("user_id");
+
+create index "posts_user_id" on public.posts using btree ("user_id");
 
 -- reactions table, FKs on users/posts tables
-create table "public"."reactions" (
+create table public.reactions (
     "user_id" integer not null references users(id) on delete cascade not deferrable,
     "post_id" integer not null references posts(id) on delete cascade not deferrable,
     "reaction" character varying(255) not null,
     constraint "reactions_user_id_post_id_reaction" unique ("user_id", "post_id", "reaction")
 );
-create index "reactions_post_id" on "public"."reactions" using btree ("post_id");
-create index "reactions_user_id" on "public"."reactions" using btree ("user_id");
+
+create index "reactions_post_id" on public.reactions using btree ("post_id");
+create index "reactions_user_id" on public.reactions using btree ("user_id");

--- a/db/migrations/001_init_private_schema.sql
+++ b/db/migrations/001_init_private_schema.sql
@@ -38,4 +38,5 @@ $$ language plpgsql strict security definer;
 -- TODO:
 --  - restrict post/reaction creation to a logged in user
 --  - add a username column?
---  - 
+--  - add roles and set default postgraphile role to anonymous role
+--  - https://www.graphile.org/postgraphile/postgresql-schema-design/#postgres-roles

--- a/db/migrations/001_init_private_schema.sql
+++ b/db/migrations/001_init_private_schema.sql
@@ -1,0 +1,41 @@
+-- 001_init_private_schema.sql
+
+-- private schema for non-public objects
+create schema "private";
+
+-- loads the "pgcrypto" extension in both schemas
+create extension if not exists "pgcrypto" schema "public";
+create extension if not exists "pgcrypto" schema "private";
+
+-- private "login_credentials" table for user login info
+create table "private"."login_credentials" (
+    "user_id" integer primary key references public.users("id") on delete cascade,
+    "email" text not null unique check (email ~* '^.+@.+\..+$'),
+    "password_hash" text not null
+);
+create index "login_credentials_email" on "private"."login_credentials" using btree ("email");
+
+-- Function for creating user accounts
+create function "public"."register_user"(
+    "name" text,
+    "email" text,
+    "password" text
+) returns "public"."users" as $$
+declare
+  "user" "public"."users";
+begin
+  insert into "public"."users" ("name") values
+    ("name")
+    returning * into "user";
+
+  insert into "private"."login_credentials" ("user_id", "email", "password_hash") values
+    ("user"."id", "email", crypt("password", gen_salt('bf')));
+
+  return "user";
+end;
+$$ language plpgsql strict security definer;
+
+-- TODO:
+--  - restrict post/reaction creation to a logged in user
+--  - add a username column?
+--  - 

--- a/db/migrations/001_private_schema.sql
+++ b/db/migrations/001_private_schema.sql
@@ -1,4 +1,4 @@
--- 001_init_private_schema.sql
+-- 001_private_schema.sql
 
 -- private schema for non-public objects
 create schema "private";

--- a/db/migrations/001_private_schema.sql
+++ b/db/migrations/001_private_schema.sql
@@ -2,41 +2,41 @@
 
 -- private schema for non-public objects
 create schema "private";
+comment on schema private is 'Private schema for non-public objects that should not be exposed through the GraphQL API.';
 
 -- loads the "pgcrypto" extension in both schemas
 create extension if not exists "pgcrypto" schema "public";
 create extension if not exists "pgcrypto" schema "private";
 
 -- private "login_credentials" table for user login info
-create table "private"."login_credentials" (
+create table private.login_credentials (
     "user_id" integer primary key references public.users("id") on delete cascade,
     "email" text not null unique check (email ~* '^.+@.+\..+$'),
     "password_hash" text not null
 );
-create index "login_credentials_email" on "private"."login_credentials" using btree ("email");
+
+create index "login_credentials_email" on private.login_credentials using btree ("email");
+
+comment on table private.login_credentials is 'Holds the email address and password_hash for a user account. 1-to-1 relation to the public.users table.';
 
 -- Function for creating user accounts
-create function "public"."register_user"(
+create function public.register_user(
     "name" text,
     "email" text,
     "password" text
-) returns "public"."users" as $$
+) returns public.users as $$
 declare
-  "user" "public"."users";
+    "user" public.users;
 begin
-  insert into "public"."users" ("name") values
-    ("name")
-    returning * into "user";
+    insert into public.users ("name")
+        values ("name")
+        returning * into "user";
 
-  insert into "private"."login_credentials" ("user_id", "email", "password_hash") values
-    ("user"."id", "email", crypt("password", gen_salt('bf')));
+    insert into private.login_credentials ("user_id", "email", "password_hash")
+        values ("user"."id", "email", crypt("password", gen_salt('bf')));
 
   return "user";
 end;
 $$ language plpgsql strict security definer;
 
--- TODO:
---  - restrict post/reaction creation to a logged in user
---  - add a username column?
---  - add roles and set default postgraphile role to anonymous role
---  - https://www.graphile.org/postgraphile/postgresql-schema-design/#postgres-roles
+comment on function public.register_user(text, text, text) is 'Creates a user account in the users table and associates a login_credentials record with the user. Allows the user to log in using an email/password combination.';

--- a/db/migrations/002_database_roles.sql
+++ b/db/migrations/002_database_roles.sql
@@ -1,0 +1,49 @@
+-- 002_database_roles.sql
+
+-- Anonymous "reader" role
+create role gripedotdev_anonymous;
+grant gripedotdev_anonymous to gripedotdev;
+comment on role gripedotdev_anonymous is 'Role for readonly access to public objects.';
+
+-- Role granted to logged in users
+create role gripedotdev_user;
+grant gripedotdev_user to gripedotdev;
+comment on role gripedotdev_user is 'Role for read/write access to public objects owned by the currently logged in user.';
+
+-- Token used to pass information for authenticated users.
+create type public.jwt_token as (
+    "role" text,
+    "user_id" integer,
+    "exp" bigint
+);
+
+-- Login function
+create function public.authenticate(
+    "email_address" text,
+    "password" text
+) returns public.jwt_token as $$
+declare
+    "account" private.login_credentials;
+begin
+    select a.* into "account"
+        from private.login_credentials as a
+        where a."email" = "email_address";
+
+    if "account"."password_hash" = crypt("password", "account"."password_hash") then
+        return ('gripedotdev_user', "account"."user_id", extract(epoch from (now() + interval '2 days')))::"public"."jwt_token";
+    else
+        return null;
+    end if;
+end;
+$$ language plpgsql strict security definer;
+
+comment on function public.authenticate(text, text) is 'Creates a JWT token that will securely identify a user and give them certain permissions. This token expires in 2 days.';
+
+-- Gets the current user
+create function public.current_user() returns public.users as $$
+    select * from
+    public.users
+    where users.id = (nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+$$ language sql stable;
+
+comment on function public.current_user() is 'Gets the user record identified by the JWT in the HTTP header.';

--- a/db/migrations/003_role_permissions.sql
+++ b/db/migrations/003_role_permissions.sql
@@ -1,0 +1,62 @@
+-- 003_role_permissions.sql
+
+-- after schema creation and before function creation
+alter default privileges revoke execute on functions from public;
+grant usage on schema public to gripedotdev_anonymous, gripedotdev_user;
+
+-- Grant query permissions on public.users to anon/user roles
+grant select on table public.users to gripedotdev_anonymous, gripedotdev_user;
+grant update, delete on table public.users to gripedotdev_user;
+
+-- Grant query permissions on public.posts to anon/user roles
+grant select on table public.posts to gripedotdev_anonymous, gripedotdev_user;
+grant insert, update, delete on table public.posts to gripedotdev_user;
+grant usage on sequence public.posts_id_seq to gripedotdev_user;
+
+-- Grant query permissions on public.reactions to anon/user roles
+grant select on table public.reactions to gripedotdev_anonymous, gripedotdev_user;
+grant insert, update, delete on table public.reactions to gripedotdev_user;
+
+-- Grant query permissions on public functions to anon/user roles
+grant execute on function public.register_user(text, text, text) to gripedotdev_anonymous;
+grant execute on function public.authenticate(text, text) to gripedotdev_anonymous, gripedotdev_user;
+grant execute on function public.current_user() to gripedotdev_anonymous, gripedotdev_user;
+
+-- Enable row-level security for tables with data owned by specific users
+alter table public.users enable row level security;
+alter table public.posts enable row level security;
+alter table public.reactions enable row level security;
+
+-- All data in public schema can be readable by anyone
+create policy select_user on public.users for select using (true);
+create policy select_post on public.posts for select using (true);
+create policy select_reaction on public.reactions for select using (true);
+
+-- A user is the only person that can update/delete their own user data
+-- Insert is omitted because insert on users table is restricted to user registration
+create policy update_user on public.users for update to gripedotdev_user
+    using ("id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+create policy delete_user on public.users for delete to gripedotdev_user
+    using ("id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+-- A user is the only person that can create/update/delete posts owned by their user ID
+create policy insert_post on public.posts for insert to gripedotdev_user
+    with check ("user_id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+create policy update_post on public.posts for update to gripedotdev_user
+    using ("user_id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+create policy delete_post on public.posts for delete to gripedotdev_user
+    using ("user_id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+-- A user is the only person that can create/delete reactions owned by their user ID
+-- Update is omitted on reactions table
+create policy insert_reaction on public.reactions for insert to gripedotdev_user
+    with check ("user_id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+create policy update_reaction on public.reactions for update to gripedotdev_user
+    using ("user_id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);
+
+create policy delete_reaction on public.reactions for delete to gripedotdev_user
+    using ("user_id" = nullif(current_setting('jwt.claims.user_id', true), '')::integer);

--- a/db/test_data.sql
+++ b/db/test_data.sql
@@ -44,3 +44,6 @@ INSERT INTO "reactions" ("user_id", "post_id", "reaction") VALUES
 (2,	8,	'🗿'),
 (3,	8,	'🗿'),
 (4,	8,	'🗿');
+
+alter sequence "users_id_seq" restart 5;
+alter sequence "posts_id_seq" restart 13;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,11 @@ services:
   graphql:
     image: graphile/postgraphile:4
     restart: always
-    entrypoint: ./cli.js --subscriptions --watch
+    entrypoint: ["./cli.js", "--watch", "--default-role", "gripedotdev_anonymous", "--jwt-token-identifier", "public.jwt_token"]
+    # Production config should include a strong --jwt-secret
+    # entrypoint: ["./cli.js", "--watch", "--default-role", "gripedotdev_anonymous", "--jwt-token-identifier", "public.jwt_token", "--jwt-secret", "some_strong_password"]
     ports:
       - "5000:5000"
-      - "5000:5000/udp"
     environment:
       DATABASE_URL: postgres://gripedotdev:password@postgres/gripedotdev
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,8 @@ services:
   graphql:
     image: graphile/postgraphile:4
     restart: always
-    entrypoint: ["./cli.js", "--watch", "--default-role", "gripedotdev_anonymous", "--jwt-token-identifier", "public.jwt_token"]
-    # Production config should include a strong --jwt-secret
-    # entrypoint: ["./cli.js", "--watch", "--default-role", "gripedotdev_anonymous", "--jwt-token-identifier", "public.jwt_token", "--jwt-secret", "some_strong_password"]
+    # Production config should include a stronger --jwt-secret
+    entrypoint: ["./cli.js", "--watch", "--default-role", "gripedotdev_anonymous", "--jwt-token-identifier", "public.jwt_token", "--jwt-secret", "some_strong_password"]
     ports:
       - "5000:5000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,10 @@ services:
   graphql:
     image: graphile/postgraphile:4
     restart: always
+    entrypoint: ./cli.js --subscriptions --watch
     ports:
       - "5000:5000"
+      - "5000:5000/udp"
     environment:
       DATABASE_URL: postgres://gripedotdev:password@postgres/gripedotdev
     networks:


### PR DESCRIPTION
Partially closes #37.

This adds the following features to the postgres schema, which are propagated to the GraphQL API:

- a private database schema for objects that shouldn't be exposed to the GraphQL API
- a table for login credentials
- functions for creating, logging in with, and testing login credentials
- support for JWT (JSON Web Tokens)
- Roles granting read access to all public objects
- Roles granting row-based create/update/delete access to public objects, based on user's ID

This PR also cleans up an earlier DB migration file, fixes a bug with test data, and adds encrypted JWT support to the GraphQL service in `docker-compose`. The result of this mess is RBAC for our app :tada:.

## Questions for you guys

- Wanna jump on a call to talk about how the auth works or are you all good?
- Do we want to make post reactions work like Slack (unlimited reactions, but only one of each type) or like Facebook (only one reaction total)? Partially related to #3 and #9.
- Should we use usernames to identify users or is email address fine? Wondering how potential users would react to another app requesting their email address. (I went with email only because the docs I followed used email address as the unique user field.)
- Do we care about federated logins for MVP1? Haven't started the research for it, don't know what it would take to add :man_shrugging:.

## Bad screenshots because it's 12:30am

![Register User](https://user-images.githubusercontent.com/16184219/95159133-45ddf000-076b-11eb-966d-48f830b01264.png)
![Screenshot from 2020-10-06 00-14-14](https://user-images.githubusercontent.com/16184219/95159139-4aa2a400-076b-11eb-889f-2a5c0d8dd9ea.png)
![Screenshot from 2020-10-06 00-15-10](https://user-images.githubusercontent.com/16184219/95159141-4c6c6780-076b-11eb-808a-b4a39324335c.png)